### PR TITLE
Updates for Endwalker Changes

### DIFF
--- a/Helpers/Abilities.cs
+++ b/Helpers/Abilities.cs
@@ -192,6 +192,7 @@
         PrecisionHookset,
         FishEyes,
         Patience2,
+        ThaliaksFavor,
         SharkEye,
         Gig,
         GigHead,

--- a/Helpers/Abilities.cs
+++ b/Helpers/Abilities.cs
@@ -122,8 +122,9 @@
                         {Ability.SurfaceSlap, 4595},
                         {Ability.IdenticalGig, 4591},
                         {Ability.IdenticalCast, 4596},
-
-
+                        {Ability.PrizeCatch, 26806},
+                        {Ability.MakeshiftBait, 26805},
+                        {Ability.TripleHook, 27523}
                     }
                 }
             };
@@ -137,7 +138,9 @@
         TruthOfMountains = 222,
         DiscerningEye = 757,
         CollectorsGlove = 805,
-        TruthOfOceans = 1173
+        TruthOfOceans = 1173,
+        PrizeCatch = 2780,
+        MakeshiftBait = 2779
     }
 
     internal enum Ability : byte
@@ -184,6 +187,7 @@
         Quit,
         CastLight,
         Release,
+        MakeshiftBait,
         Mooch,
         Snagging,
         Patience,
@@ -207,5 +211,7 @@
         SurfaceSlap,
         IdenticalGig,
         IdenticalCast,
+        PrizeCatch,
+        TripleHook
     }
 }

--- a/Helpers/Abilities.cs
+++ b/Helpers/Abilities.cs
@@ -104,6 +104,7 @@
                         {Ability.PowerfulHookset, 4103},
                         {Ability.Chum, 4104},
                         {Ability.PrecisionHookset, 4179},
+                        {Ability.ThaliaksFavor, 26804},
                         {Ability.FishEyes, 4105},
                         {Ability.Patience2, 4106},
                         {Ability.SharkEye, 7904},

--- a/Localization/Localization.Designer.cs
+++ b/Localization/Localization.Designer.cs
@@ -448,6 +448,42 @@ namespace ExBuddy.Localization {
         }
         
         /// <summary>
+        ///   Searches for a localized string similar to Prize Catch activated..
+        /// </summary>
+        internal static string ExFish_PrizeCatch {
+            get {
+                return ResourceManager.GetString("ExFish_PrizeCatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Searches for a localized string similar to Makeshift Bait activated..
+        /// </summary>
+        internal static string ExFish_MakeshiftBait {
+            get {
+                return ResourceManager.GetString("ExFish_MakeshiftBait", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Searches for a localized string similar to Triple Hook activated..
+        /// </summary>
+        internal static string ExFish_DoubleHook {
+            get {
+                return ResourceManager.GetString("ExFish_DoubleHook", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Searches for a localized string similar to Triple Hook activated..
+        /// </summary>
+        internal static string ExFish_TripleHook {
+            get {
+                return ResourceManager.GetString("ExFish_TripleHook", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Released .
         /// </summary>
         internal static string ExFish_Release {

--- a/Localization/Localization.Designer.cs
+++ b/Localization/Localization.Designer.cs
@@ -439,6 +439,15 @@ namespace ExBuddy.Localization {
         }
         
         /// <summary>
+        ///   Searches for a localized string similar to Patience activated..
+        /// </summary>
+        internal static string ExFish_ThaliaksFavor {
+            get {
+                return ResourceManager.GetString("ExFish_ThaliaksFavor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Released .
         /// </summary>
         internal static string ExFish_Release {

--- a/Localization/Localization.resx
+++ b/Localization/Localization.resx
@@ -213,6 +213,9 @@
   <data name="ExFish_Patience" xml:space="preserve">
     <value>Patience activated</value>
   </data>
+  <data name="ExFish_ThaliaksFavor" xml:space="preserve">
+    <value>Thaliak's Favor activated</value>
+  </data>
   <data name="ExFish_Release" xml:space="preserve">
     <value>Released {0}.</value>
   </data>

--- a/Localization/Localization.resx
+++ b/Localization/Localization.resx
@@ -216,6 +216,18 @@
   <data name="ExFish_ThaliaksFavor" xml:space="preserve">
     <value>Thaliak's Favor activated</value>
   </data>
+  <data name="ExFish_PrizeCatch" xml:space="preserve">
+    <value>Prize Catch activated</value>
+  </data>
+  <data name="ExFish_MakeshiftBait" xml:space="preserve">
+    <value>Makeshift Bait activated</value>
+  </data>
+  <data name="ExFish_DoubleHook" xml:space="preserve">
+    <value>Double Hook activated</value>
+  </data>
+  <data name="ExFish_TripleHook" xml:space="preserve">
+    <value>Triple Hook activated</value>
+  </data>
   <data name="ExFish_Release" xml:space="preserve">
     <value>Released {0}.</value>
   </data>

--- a/OrderBotTags/Fish/ExFishTag.cs
+++ b/OrderBotTags/Fish/ExFishTag.cs
@@ -879,13 +879,13 @@ namespace ExBuddy.OrderBotTags.Fish
 			{
 				return
 					new Decorator(
-						ret => ThaliaksFavor && Core.Player.Auras.GetAuraStacksById(2778) >= 3
+						ret => ThaliaksFavor && Core.Player.Auras.GetAuraStacksById(2778) >= 3 && CanDoAbility(Ability.ThaliaksFavor)
 							   && (FishingManager.State == FishingState.None || FishingManager.State == FishingState.PoleReady)
 							   && (ExProfileBehavior.Me.CurrentGP <= MaximumGPThaliaksFavor || (ExProfileBehavior.Me.MaxGP - ExProfileBehavior.Me.CurrentGP) > 200),
 						new Sequence(new Action(r => 
 						{
-							ActionManager.DoAction(26804, Core.Me);
-							Logger.Info("Angler's Art: {0}", Core.Player.Auras.GetAuraStacksById(2778));
+							DoAbility(Ability.ThaliaksFavor);
+							Logger.Info(Localization.Localization.ExFish_ThaliaksFavor);
 						}
 						), new Sleep(1, 2)));
 			}

--- a/OrderBotTags/Fish/ExFishTag.cs
+++ b/OrderBotTags/Fish/ExFishTag.cs
@@ -67,6 +67,7 @@ namespace ExBuddy.OrderBotTags.Fish
 					ReleaseComposite,
 					IdenticalCastComposite,
 					MoochComposite,
+					ThaliaksFavorComposite,
 					FishCountLimitComposite,
 					InventoryFullComposite,
 					SitComposite,
@@ -645,6 +646,13 @@ namespace ExBuddy.OrderBotTags.Fish
 		[XmlAttribute("MinimumGPPatience")]
 		public int MinimumGPPatience { get; set; }
 
+		[XmlAttribute("ThaliaksFavor")]
+		public bool ThaliaksFavor { get; set; }
+
+		[DefaultValue(600)]
+		[XmlAttribute("MaximumGPThaliaksFavor")]
+		public int MaximumGPThaliaksFavor { get; set; }
+
 		[XmlAttribute("FishEyes")]
 		public bool FishEyes { get; set; }
 
@@ -862,6 +870,24 @@ namespace ExBuddy.OrderBotTags.Fish
 									Logger.Info(Localization.Localization.ExFish_Patience);
 								}),
 							new Sleep(1, 2)));
+			}
+		}
+
+		protected Composite ThaliaksFavorComposite
+		{
+			get
+			{
+				return
+					new Decorator(
+						ret => ThaliaksFavor && Core.Player.Auras.GetAuraStacksById(2778) >= 3
+							   && (FishingManager.State == FishingState.None || FishingManager.State == FishingState.PoleReady)
+							   && (ExProfileBehavior.Me.CurrentGP <= MaximumGPThaliaksFavor || (ExProfileBehavior.Me.MaxGP - ExProfileBehavior.Me.CurrentGP) > 200),
+						new Sequence(new Action(r => 
+						{
+							ActionManager.DoAction(26804, Core.Me);
+							Logger.Info("Angler's Art: {0}", Core.Player.Auras.GetAuraStacksById(2778));
+						}
+						), new Sleep(1, 2)));
 			}
 		}
 

--- a/OrderBotTags/Schema/Fish.xsd
+++ b/OrderBotTags/Schema/Fish.xsd
@@ -63,6 +63,11 @@
 			<xs:attribute name="sit" type="xs:boolean"></xs:attribute>
 			<xs:attribute name="sitRate" type="xs:float"></xs:attribute>
 			<xs:attribute name="fishEyes" type="xs:boolean"></xs:attribute>
+			<xs:attribute name="thaliaksFavor" type="xs:boolean"></xs:attribute>
+			<xs:attribute name="prizeCatch" type="xs:boolean"></xs:attribute>
+			<xs:attribute name="makeshiftBait" type="xs:boolean"></xs:attribute>
+			<xs:attribute name="doubleHook" type="xs:boolean"></xs:attribute>
+			<xs:attribute name="tripleHook" type="xs:boolean"></xs:attribute>
 		</xs:complexType>
 	</xs:element>
 	<xs:simpleType name="Abilities">
@@ -83,8 +88,13 @@
 			<xs:enumeration value="PowerfulHookset" />
 			<xs:enumeration value="Chum" />
 			<xs:enumeration value="FishEyes" />
+			<xs:enumeration value="ThaliaksFavor" />
+			<xs:enumeration value="PrizeCatch" />
+			<xs:enumeration value="MakeshiftBait" />
 			<xs:enumeration value="PrecisionHookset" />
 			<xs:enumeration value="Patience2" />
+			<xs:enumeration value="DoubleHook" />
+			<xs:enumeration value="TripleHook" />
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="VirtualKeys">


### PR DESCRIPTION
Adds support for each Fisher action below with the listed options supported in the XML schema.

- **ThaliaksFavor**: Boolean. Enables use of Thaliak's Favor. When enabled, will trigger if MissingGP is greater than 200 and CurrentGP above MaximumGPThaliaksFavor value.
- **MaximumGPThaliaksFavor**: Integer. When set will not use Thaliak's Favor if GP is above this value. 600GP default value.
- **PrizeCatch**: Boolean. Enables use of Prize Catch. When enabled, if CurrentGP is above MiminimGPPrizeCatch value.
- **MiminimGPPrizeCatch**: Integer. When set will not use Prize Catch if CurrentGP is below this value. 600GP default
- **MakeshiftBait**: Boolean. Enables use of Makeshift Bait when Angler's Art is 5 or more and fish is a "mooch" fish.
- **DoubleHook**: Boolean. Enables use of Double Hook instead of Hook. Has priority over Hook.
- **TripleHook**: Boolean. Enables use of Double Hook instead of Hook. Has priority over Double Hook.