### PR TITLE
Surface Slap

### DIFF
--- a/Enumerations/SurfaceSlapAction.cs
+++ b/Enumerations/SurfaceSlapAction.cs
@@ -1,0 +1,22 @@
+﻿namespace ExBuddy.Enumerations
+{
+    using System;
+
+    [Serializable]
+    [Flags]
+    public enum SurfaceSlapAction : byte
+    {
+        DontKeep = 0x00,
+
+        KeepNq = 0x01,
+
+        KeepHq = 0x02,
+
+        // MoochFlag = 0x04,
+        KeepAll = 0x03, // KeepNq | KeepHq
+
+        Mooch = 0x06, // KeepHq | MoochFlag
+
+        MoochKeepNq = 0x07 // KeepNq | KeepHq | MoochFlag
+    }
+}

--- a/ExBuddy.csproj
+++ b/ExBuddy.csproj
@@ -235,7 +235,9 @@
     <Compile Include="OrderBotTags\Fish\FishResult.cs" />
     <Compile Include="OrderBotTags\Fish\FishSpots\FishSpot.cs" />
     <Compile Include="OrderBotTags\Fish\Keeper.cs" />
+    <Compile Include="OrderBotTags\Fish\SurfaceSlap.cs" />
     <Compile Include="Enumerations\KeeperAction.cs" />
+    <Compile Include="Enumerations\SurfaceSlapAction.cs" />
     <Compile Include="Enumerations\VirtualKeys.cs" />
     <Compile Include="OrderBotTags\Gather\ExGatherTag.cs" />
     <Compile Include="Enumerations\GatherIncrease.cs" />

--- a/Localization/Localization.Designer.cs
+++ b/Localization/Localization.Designer.cs
@@ -439,11 +439,11 @@ namespace ExBuddy.Localization {
         }
         
         /// <summary>
-        ///   Searches for a localized string similar to Patience activated.
+        ///   Searches for a localized string similar to Surfaceslap activated.
         /// </summary>
         internal static string ExFish_SurfaceSlap {
             get {
-                return ResourceManager.GetString("ExFish_SurfaceSlapPatience", resourceCulture);
+                return ResourceManager.GetString("ExFish_SurfaceSlap", resourceCulture);
             }
         }
         

--- a/Localization/Localization.Designer.cs
+++ b/Localization/Localization.Designer.cs
@@ -439,7 +439,16 @@ namespace ExBuddy.Localization {
         }
         
         /// <summary>
-        ///   Searches for a localized string similar to Patience activated..
+        ///   Searches for a localized string similar to Patience activated.
+        /// </summary>
+        internal static string ExFish_SurfaceSlap {
+            get {
+                return ResourceManager.GetString("ExFish_SurfaceSlapPatience", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Searches for a localized string similar to Thaliak's Favor activated.
         /// </summary>
         internal static string ExFish_ThaliaksFavor {
             get {
@@ -448,7 +457,7 @@ namespace ExBuddy.Localization {
         }
         
         /// <summary>
-        ///   Searches for a localized string similar to Prize Catch activated..
+        ///   Searches for a localized string similar to Prize Catch activated.
         /// </summary>
         internal static string ExFish_PrizeCatch {
             get {
@@ -457,7 +466,7 @@ namespace ExBuddy.Localization {
         }
         
         /// <summary>
-        ///   Searches for a localized string similar to Makeshift Bait activated..
+        ///   Searches for a localized string similar to Makeshift Bait activated.
         /// </summary>
         internal static string ExFish_MakeshiftBait {
             get {
@@ -466,7 +475,7 @@ namespace ExBuddy.Localization {
         }
         
         /// <summary>
-        ///   Searches for a localized string similar to Triple Hook activated..
+        ///   Searches for a localized string similar to Double Hook activated.
         /// </summary>
         internal static string ExFish_DoubleHook {
             get {
@@ -475,7 +484,7 @@ namespace ExBuddy.Localization {
         }
         
         /// <summary>
-        ///   Searches for a localized string similar to Triple Hook activated..
+        ///   Searches for a localized string similar to Triple Hook activated.
         /// </summary>
         internal static string ExFish_TripleHook {
             get {

--- a/Localization/Localization.resx
+++ b/Localization/Localization.resx
@@ -214,7 +214,7 @@
     <value>Patience activated</value>
   </data>
   <data name="ExFish_SurfaceSlap" xml:space="preserve">
-    <value>Surface Slap activated.</value>
+    <value>Surface Slap activated {0}</value>
   </data>
   <data name="ExFish_ThaliaksFavor" xml:space="preserve">
     <value>Thaliak's Favor activated</value>

--- a/Localization/Localization.resx
+++ b/Localization/Localization.resx
@@ -213,6 +213,9 @@
   <data name="ExFish_Patience" xml:space="preserve">
     <value>Patience activated</value>
   </data>
+  <data name="ExFish_SurfaceSlap" xml:space="preserve">
+    <value>Surface Slap activated.</value>
+  </data>
   <data name="ExFish_ThaliaksFavor" xml:space="preserve">
     <value>Thaliak's Favor activated</value>
   </data>

--- a/OrderBotTags/Fish/ExFishTag.cs
+++ b/OrderBotTags/Fish/ExFishTag.cs
@@ -190,6 +190,11 @@ namespace ExBuddy.OrderBotTags.Fish
 				Keepers = new List<Keeper>();
 			}
 
+			if (SurfaceSlaps == null)
+			{
+				SurfaceSlaps = new List<SurfaceSlap>();
+			}
+
 			if (Collect && Collectables == null)
 			{
 				Collectables = new List<Collectable> { new Collectable { Name = string.Empty, Value = (int)CollectabilityValue } };
@@ -576,9 +581,6 @@ namespace ExBuddy.OrderBotTags.Fish
 		[XmlElement("Keepers")]
 		public List<Keeper> Keepers { get; set; }
 
-		[XmlElement("SurfaceSlaps")]
-		public List<SurfaceSlap> SurfaceSlaps { get; set; }
-
 		[XmlElement("Collectables")]
 		public List<Collectable> Collectables { get; set; }
 
@@ -636,6 +638,13 @@ namespace ExBuddy.OrderBotTags.Fish
 		[XmlAttribute("EnableKeeper")]
 		public bool EnableKeeper { get; set; }
 
+		[DefaultValue(false)]
+		[XmlAttribute("KeepNone")]
+		public bool KeepNone { get; set; }
+
+		[XmlElement("SurfaceSlaps")]
+		public List<SurfaceSlap> SurfaceSlaps { get; set; }
+
 		[DefaultValue(true)]
 		[XmlAttribute("EnableSurfaceSlap")]
 		public bool EnableSurfaceSlap { get; set; }
@@ -643,10 +652,6 @@ namespace ExBuddy.OrderBotTags.Fish
 		[DefaultValue(300)]
 		[XmlAttribute("MinimumGPSurfaceSlap")]
 		public int MinimumGPSurfaceSlap { get; set; }
-
-		[DefaultValue(false)]
-		[XmlAttribute("KeepNone")]
-		public bool KeepNone { get; set; }
 
 		[XmlAttribute("SitRate")]
 		public float SitRate { get; set; }
@@ -1047,16 +1052,20 @@ namespace ExBuddy.OrderBotTags.Fish
 				return
 					new Decorator(
 						ret => 
-							EnableSurfaceSlap && CanDoAbility(Ability.SurfaceSlap) && (MoochLevel == 0 || !CanDoAbility(Ability.Mooch)) 
-							&& FishingManager.State == FishingState.PoleReady
-							&& (ExProfileBehavior.Me.CurrentGP >= MinimumGPSurfaceSlap || ExProfileBehavior.Me.CurrentGPPercent > 99.0f)
+							EnableSurfaceSlap && FishingManager.State == FishingState.PoleReady && CanDoAbility(Ability.SurfaceSlap)
+							// && (ExProfileBehavior.Me.CurrentGP >= MinimumGPSurfaceSlap || ExProfileBehavior.Me.CurrentGPPercent > 99.0f),
+							// && (MoochLevel == 0 || !CanDoAbility(Ability.Mooch))
 							&& SurfaceSlaps.Any(s => string.Equals(s.Name, FishResult.FishName, StringComparison.InvariantCultureIgnoreCase)),
 						new Sequence(
 							new Action(
 								r =>
 								{
 									DoAbility(Ability.SurfaceSlap);
-									Logger.Info(Localization.Localization.ExFish_SurfaceSlap);//FishResult.FishName);
+									Logger.Info(Localization.Localization.ExFish_SurfaceSlap, FishResult.FishName);
+									// foreach (var slap in SurfaceSlaps)
+									// {
+									// 	Logger.Info("SurfaceSlaps: " + Slap);
+									// }
 								}),
 							new Sleep(2, 2)));
 			}
@@ -1070,7 +1079,7 @@ namespace ExBuddy.OrderBotTags.Fish
 					new Decorator(
 						ret =>
 							checkRelease && FishingManager.State == FishingState.PoleReady && CanDoAbility(Ability.Release)
-							&& (Keepers.Count != 0 || KeepNone) && SurfaceSlaps.Count != 0,
+							&& (Keepers.Count != 0 || KeepNone),// && SurfaceSlaps.Count != 0,
 						new Sequence(
 							new Wait(
 								2,

--- a/OrderBotTags/Fish/SurfaceSlap.cs
+++ b/OrderBotTags/Fish/SurfaceSlap.cs
@@ -1,0 +1,22 @@
+namespace ExBuddy.OrderBotTags.Fish
+{
+    using Clio.XmlEngine;
+    using ExBuddy.Enumerations;
+    using System.ComponentModel;
+
+    [XmlElement("SurfaceSlap")]
+    public class SurfaceSlap
+    {
+        [DefaultValue(SurfaceSlapAction.KeepAll)]
+        [XmlAttribute("Action")]
+        public SurfaceSlapAction Action { get; set; }
+
+        [XmlAttribute("Name")]
+        public string Name { get; set; }
+
+        public override string ToString()
+        {
+            return this.DynamicToString();
+        }
+    }
+}

--- a/OrderBotTags/Schema/Fish.xsd
+++ b/OrderBotTags/Schema/Fish.xsd
@@ -28,6 +28,18 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
+				<xs:element minOccurs="0" name="SurfaceSlaps">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="SurfaceSlap" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:attribute name="name" type="xs:string" use="required"></xs:attribute>
+									<xs:attribute name="action" type="SurfaceSlapAction"></xs:attribute>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
 				<xs:element name="FishSpots">
 					<xs:complexType>
 						<xs:sequence>
@@ -298,6 +310,16 @@
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="KeeperAction">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontKeep" />
+			<xs:enumeration value="KeepNq" />
+			<xs:enumeration value="KeepHq" />
+			<xs:enumeration value="KeepAll" />
+			<xs:enumeration value="Mooch" />
+			<xs:enumeration value="MoochKeepNq" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SurfaceSlapAction">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="DontKeep" />
 			<xs:enumeration value="KeepNq" />


### PR DESCRIPTION
Adds support for Surface Slap with a XML boolean attribute "EnableSurfaceSlap" to enable/disable. Defaults to true. Can also add SurfaceSlaps/SurfaceSlap in the XML the same way it's done for Keepers/Keeper. aka

```
<SurfaceSlaps>
    <SurfaceSlap name="Lamp Marimo" />
</Surfaceslaps>
```